### PR TITLE
return links, as well as nodes, for era graph

### DIFF
--- a/stratigraph/api.py
+++ b/stratigraph/api.py
@@ -18,6 +18,7 @@ from stratigraph.ns import GEOCHRON, LEXICON
 
 logging.basicConfig(level=logging.DEBUG)
 
+
 def load_graph():
     """Interface to our graph store.
     Loaded via Depends() below to make mock testing much easier
@@ -57,6 +58,12 @@ async def geo_era(code: str,
     """
     uri = str(GEOCHRON[code])
     g = graph.in_era(uri)
+
     logging.debug(g)
-    dot = graph_to_dot(g)
-    return PlainTextResponse(dot)
+    response = ''
+    if not format or format == 'dot':
+        response = graph_to_dot(g)
+    if format == 'ttl':
+        response = g.serialize(format='ttl')
+
+    return PlainTextResponse(response)

--- a/stratigraph/graph.py
+++ b/stratigraph/graph.py
@@ -23,7 +23,7 @@ from stratigraph.lex_age_colours import COLOURS as AGE_COLOURS
 
 logging.basicConfig(level=logging.DEBUG)
 
-COLOURS = { 'age': AGE_COLOURS, 'digmap' : DIGMAP_COLOURS}
+COLOURS = {'age': AGE_COLOURS, 'digmap': DIGMAP_COLOURS}
 LEX_BASEURL = 'http://data.bgs.ac.uk/id/Lexicon/NamedRockUnit/'
 LEX = Namespace('http://data.bgs.ac.uk/ref/Lexicon/Extended/')
 
@@ -171,7 +171,8 @@ def ttl_to_nx(graph=None, triples=None, colour_scale='digmap'):
 
         # Node attributes should be added when calling add_node
         # We add the URL and also want the node colour.
-        # Not all Lexicon codes have DigMap colours, however - default to pale grey
+        # Not all Lexicon codes have DigMap colours, however - default to pale
+        # grey
         colours = COLOURS.get(colour_scale, {})
         colour = colours.get(str(url), '#EEEEEE')
         gdot.add_node(label, url=str(url), style='filled', fillcolor=colour)
@@ -200,7 +201,10 @@ def graph_to_dot(graph=None, triples=None, colour_scale='digmap'):
     Accepts either digmap or age for colour scale used for the graph
     Returns a Graphviz dotfile (rendered for us by networkx)"""
     # Translate our RDF graph into a networkx one
-    nx_graph = ttl_to_nx(graph=graph, triples=triples, colour_scale=colour_scale)
+    nx_graph = ttl_to_nx(
+        graph=graph,
+        triples=triples,
+        colour_scale=colour_scale)
     logging.debug(nx_graph)
     # Out might be a filename or a filehandle
     return to_pydot(nx_graph).to_string()


### PR DESCRIPTION
* Previously we only had nodes, not edges in the .dot output
* Adds an optional .ttl output to the API as well
* CONSTRUCT two graphs (with upper and lower links) and add them
* also adds some small autopep8 / flake8 corrections

I couldn't see a cleaner way to do this (e.g. `CONSTRUCT` won't accept an `OPTIONAL` clause). This way we collect two graphs, one for upper and one for lower boundary relations, and add them together before returning a unified graph.
