### PR TITLE
Docker build for the API, and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8
+
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+WORKDIR /app/stratigraph
+COPY stratigraph /app/stratigraph
+WORKDIR /app
+COPY stratigraph/api.py /app/main.py

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ See the instructions in that project for [Running CoreNLP in docker](https://git
 
 ## Running the application
 
+Kill any existing containers using port 80 or 3030 
+
+```
+docker container ls
+docker rm -f <container-name>
+```
+
 ```
 docker-compose up -d
 ```

--- a/README.md
+++ b/README.md
@@ -8,13 +8,31 @@ export PYTHONPATH=.
 py.test
 ```
 
-## Running
+## Running the text mining
 
 The scripts and tests depend on having Stanford CoreNLP Server with the BGS custom model for Lexicon and Geochronology named entity recognition.
 
 See the instructions in that project for [Running CoreNLP in docker](https://github.com/BritishGeologicalSurvey/geo-ner-model#running-in-docker) using our docker image in Github Container Registry. This requires authentication; see also (https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry)[authenticating with the Github Container Registry]
 
-Note - eventually we want a multi-container network with (graph storage/query), (text mining service) and (application API and frontend)
+## Running the application
+
+```
+docker-compose up -d
+```
+
+On first run this should build the API container (which you can also build with `docker build . -t bgs/strat`.
+Fuseki (the graph store) will look in `./data/fuseki` for its databases and the Fuseki container will create this directory if it doesn't exist.
+
+At present the easiest way to get running with sample data is to use the same script as the integration tests (which collects some BGS Lexicon data from [data.bgs.ac.uk](https://data.bgs.ac.uk/) and then loads the sample extract of the Jurassic graph included in this repository. (Requires Python 3).
+
+
+```
+export PYTHONPATH=.
+pip install -r requirements.txt
+python integration/fuseki_load.py
+```
+
+The intention is to improve the distribution so that Fuseki loads the whole Lexicon graph on startup, with the ability to reproduce the dataset from scratch using the [custom CoreNLP server container](https://github.com/BritishGeologicalSurvey/geo-ner-model#running-in-docker) as above.
 
 
 ## Licence

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,12 @@ services:
     ports:
       - 3030:3030
     restart: unless-stopped
+
+  api:
+    image: bgs/strat
+    build: .
+    environment:
+      - ENDPOINT=http://fuseki:3030/stratigraph/query
+    ports:
+      - 80:80
+

--- a/stratigraph/__init__.py
+++ b/stratigraph/__init__.py
@@ -1,4 +1,4 @@
 
-from ._version import get_versions
+from stratigraph._version import get_versions
 __version__ = get_versions()['version']
 del get_versions


### PR DESCRIPTION
Provides a Dockerfile (based on the standard FastAPI base image) and a `docker-compose.yml` to run it in a network with a Fuseki container. Includes documentation on bootstrapping the graph store on the first run using the same python script used in the integration tests in CI.

There are a few useful options for loading data at startup which would be better than this in that no local dependencies would be needed, so this is an intermediate step. https://hub.docker.com/r/stain/jena-fuseki 

See the changes to `README.md` for the steps to go through (currently) to load sample data after starting the graph storage container for the first time. Then http://localhost/era/J should return the Jurassic graph (but I probably need to test this again). Any feedback appreciated,