### PR TITLE
Small changes to API responses 

### DIFF
--- a/stratigraph/api.py
+++ b/stratigraph/api.py
@@ -34,7 +34,7 @@ def load_graph():
 app = FastAPI()
 
 
-@app.get("/lex/")
+@app.get("/stratigraph/lex/")
 async def lex_code(format: Optional[str] = 'dot',
                    colours: Optional[str] = 'digmap',
                    graph=Depends(load_graph)):
@@ -53,7 +53,7 @@ async def lex_code(format: Optional[str] = 'dot',
     return PlainTextResponse(response)
 
 
-@app.get("/era/{code}")
+@app.get("/stratigraph/era/{code}")
 async def geo_era(code: str,
                   full: bool = False,
                   groups: bool = False,

--- a/stratigraph/api.py
+++ b/stratigraph/api.py
@@ -57,6 +57,7 @@ async def lex_code(format: Optional[str] = 'dot',
 async def geo_era(code: str,
                   full: bool = False,
                   groups: bool = False,
+                  orphans: bool = False,
                   format: Optional[str] = 'dot',
                   colours: Optional[str] = 'digmap',
                   graph=Depends(load_graph)):
@@ -70,9 +71,11 @@ async def geo_era(code: str,
     Optional 'groups' to show both Formation and Group rank
 
     Optional 'colours' (default 'digmap', or 'age' for ICS colours)
+
+    Optional 'orphans' (default False) - show detached nodes
     """
     uri = str(GEOCHRON[code])
-    g = graph.graph_by_era(uri, full=full, groups=groups)
+    g = graph.graph_by_era(uri, full=full, groups=groups, orphan_nodes=orphans)
 
     logging.debug(g)
     if not format or format == 'dot':

--- a/stratigraph/store.py
+++ b/stratigraph/store.py
@@ -23,7 +23,8 @@ def sum_graphs(g1, g2):
 class GraphStore():
     """Intended as an abstraction in front of a graph store"""
 
-    def graph_by_era(self, era_uri, full=False, groups=False):
+    def graph_by_era(self, era_uri, full=False, groups=False,
+                     orphan_nodes=False):
         """
         Accepts the URI for a geochron concept
         Retrieves the upper/lower boundary relations

--- a/tests/fixtures/jurassic.ttl
+++ b/tests/fixtures/jurassic.ttl
@@ -12,3 +12,5 @@
 <http://data.bgs.ac.uk/id/Lexicon/NamedRockUnit/SFG> rdfs:label "Sandsfoot Grit Member" .
 
 <http://data.bgs.ac.uk/id/Lexicon/NamedRockUnit/KC> rdfs:label "Kimmeridge Clay Formation" .
+
+<http://data.bgs.ac.uk/id/Lexicon/NamedRockUnit/NULL> rdfs:label "Null Formation" .

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,13 +26,13 @@ app.dependency_overrides[load_graph] = load_test_graph
 
 
 def test_lex():
-    response = client.get("/lex/")
+    response = client.get("/stratigraph/lex/")
     assert response.status_code == 200
     assert 'digraph' in str(response.content)
 
 
 def test_era():
     name = 'Carboniferous'
-    response = client.get(f"/era/{name}")
+    response = client.get(f"/stratigraph/era/{name}")
     assert response.status_code == 200
     assert 'digraph' in str(response.content)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -55,9 +55,13 @@ def test_ttl_to_nx():
     nx_graph = ttl_to_nx(graph=graph)
     assert not is_empty(nx_graph)
 
-    # Case in which we only supply some triples
+    # Case in which we only supply triples, not graph
     nx_graph = ttl_to_nx(triples=triples)
     assert not is_empty(nx_graph)
+
+    # Case in which we include orphaned nodes
+    nx_full_graph = ttl_to_nx(triples=triples, orphan_nodes=False)
+    assert nx_full_graph.number_of_nodes() < nx_graph.number_of_nodes()
 
     # Case in which we use the age colour scale
     nx_graph_age = ttl_to_nx(triples=triples, colour_scale='age')


### PR DESCRIPTION
After team preview of the front-end, the couple of small feature changes discussed:

* Endpoints prefixed by `/stratigraph` for ease of proxying
* `orphans` option to `/era` endpoint to include or omit unlinked nodes (omit by default) - note this only affects the networkx output, we keep them in the RDF output


