### PR TITLE
add URL as 'id' to dotfile

### DIFF
--- a/stratigraph/graph.py
+++ b/stratigraph/graph.py
@@ -221,7 +221,11 @@ def ttl_to_nx(graph=None,
         # Not all Lexicon codes have DigMap colours, however - default to pale
         # grey
         colour = colours.get(str(url), '#EEEEEE')
-        gdot.add_node(label, url=str(url), style='filled', fillcolor=colour)
+        gdot.add_node(label,
+                      id=str(url),
+                      url=str(url),
+                      style='filled',
+                      fillcolor=colour)
 
         for strat in uppers:
             # don't add self-referential edges

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -88,3 +88,4 @@ def test_graph_to_dot():
     # read it back in when sending via the API?
     dot = graph_to_dot(graph=graph)
     assert 'data.bgs.ac.uk' in dot
+    assert 'id=' in dot


### PR DESCRIPTION
When set as `id` the URL is then re-used as the node ID in the JS rendered SVG.

I left the `url` property in the dotfile just in case anything depends on it.

