### PR TITLE
using devel release (jena 4) of stain/jena-fuseki docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   fuseki:
-    image: stain/jena-fuseki:3.14.0
+    image: stain/jena-fuseki:devel
     environment:
       - ADMIN_PASSWORD=admin
       - JVM_ARGS=-Xmx2g


### PR DESCRIPTION
fixes TBD lock issue that arises on container restart